### PR TITLE
AL-1857 Fix Composite Monitors Cannot Use Dry Run

### DIFF
--- a/data_kennel/config.py
+++ b/data_kennel/config.py
@@ -290,10 +290,11 @@ class Config(object):
 
         for query in sub_queries:
             # Create a new monitor for each
-            sub_monitor = {'name': SUB_MONITOR_NAME_TEMPLATE.format(name, index),
-                           'type': monitor['type'],
-                           'tags': tags,
-                          }
+            sub_monitor = {
+                'name': SUB_MONITOR_NAME_TEMPLATE.format(name, index),
+                'type': monitor['type'],
+                'tags': tags,
+            }
             if monitor.get('options'):
                 sub_monitor['options'] = monitor.get('options')
             sub_monitor['query'] = query.strip()

--- a/data_kennel/monitor.py
+++ b/data_kennel/monitor.py
@@ -4,6 +4,8 @@ Data Kennel class for orchestrating management of Datadog monitors.
 import logging
 import json
 import difflib
+import random
+import string
 
 from datadog import api, initialize
 
@@ -215,11 +217,19 @@ class Monitor(object):
 
                 if not dry_run:
                     return api.Monitor.update(**merged_monitor)
+                else:
+                    return merged_monitor
         else:
             logger.info('Creating monitor: %s', configured_monitor['name'])
 
             if not dry_run:
                 return api.Monitor.create(**configured_monitor)
+            else:
+                # If we are making fake monitors for a composite monitor, then we need to insert a fake id for
+                # the monitor to have.
+                fake_id = ''.join(random.choice(string.digits + string.ascii_uppercase) for _ in range(12))
+                configured_monitor["id"] = fake_id
+                return configured_monitor
 
     def _is_principal_monitor(self, monitor):
         """

--- a/data_kennel/monitor.py
+++ b/data_kennel/monitor.py
@@ -5,7 +5,6 @@ import logging
 import json
 import difflib
 import random
-import string
 
 from datadog import api, initialize
 
@@ -217,19 +216,19 @@ class Monitor(object):
 
                 if not dry_run:
                     return api.Monitor.update(**merged_monitor)
-                else:
-                    return merged_monitor
+
+                return merged_monitor
         else:
             logger.info('Creating monitor: %s', configured_monitor['name'])
 
             if not dry_run:
                 return api.Monitor.create(**configured_monitor)
-            else:
-                # If we are making fake monitors for a composite monitor, then we need to insert a fake id for
-                # the monitor to have.
-                fake_id = ''.join(random.choice(string.digits + string.ascii_uppercase) for _ in range(12))
-                configured_monitor["id"] = fake_id
-                return configured_monitor
+
+            # If we are making fake monitors for a composite monitor, then we need to insert a fake id for
+            # the monitor to have.
+            fake_id = ''.join(random.choice('ABCDEF1234567890') for _ in range(12))
+            configured_monitor["id"] = fake_id
+            return configured_monitor
 
     def _is_principal_monitor(self, monitor):
         """

--- a/data_kennel/version.py
+++ b/data_kennel/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_monitor.py
+++ b/test/unit/test_monitor.py
@@ -450,6 +450,14 @@ class DataKennelMonitorTests(TestCase):
         monitor_api.update.assert_not_called()
         monitor_api.delete.assert_not_called()
 
+    def test_update_composite_create_dry_run(self, monitor_api):
+        """Tests that update handles composite monitors while in dry-run"""
+        self.composite_monitor_1.update(dry_run=True)
+
+        monitor_api.create.assert_not_called()
+        monitor_api.update.assert_not_called()
+        monitor_api.delete.assert_not_called()
+
     def test_update_creates_multi_team_monitors(self, monitor_api):
         """Update composite monitor makes correct calls"""
         monitor_bar1 = {'id': 'bar1'}


### PR DESCRIPTION
Fixed issue where if one tried to dry-run creating a new composite
monitor, it wouldn't work because the sub-monitors would not be
returned. Updated the helper function that actually creates the monitors
to always return a valid monitor configuration. Additionally, if it is
creating a new monitor but is in dry-run mode, the helper function now
generates a fake monitor id and includes that in the response. Also
added an unit test covering this behavior.