### PR TITLE
AL-1944 Fix Interpolation Bug

### DIFF
--- a/data_kennel/config.py
+++ b/data_kennel/config.py
@@ -9,7 +9,7 @@ import re
 import json
 import logging
 import yaml
-from schema import Schema, Optional, Or, Use, SchemaError
+from schema import Schema, Optional, Or, Use, SchemaError, Regex
 
 from data_kennel.util import convert_dict_to_tags, is_truthy, convert_tags_to_dict
 from data_kennel import __version__
@@ -17,6 +17,8 @@ from data_kennel import __version__
 DEFAULT_RECOVERY_MESSAGE = "This alert has recovered."
 VARIABLE_PATTERN = "(\\$\\{.+?\\})"
 SUB_MONITOR_NAME_TEMPLATE = '[DK-C] {0} -- {1}'
+
+VARIABLE_VALIDATOR = Regex(VARIABLE_PATTERN)
 
 CONFIG_SCHEMA = Schema(
     {
@@ -44,22 +46,22 @@ CONFIG_SCHEMA = Schema(
                     Optional('silenced', default=None): {
                         str: Or(None, Use(int))
                     },
-                    Optional('notify_no_data'): Use(is_truthy),
-                    Optional('new_host_delay'): Or(Use(int), str),
-                    Optional('no_data_timeframe'): Or(Use(int), str),
-                    Optional('timeout_h'): Use(int),
-                    Optional('require_full_window'): Use(is_truthy),
-                    Optional('renotify_interval'): Or(Use(int), str),
+                    Optional('notify_no_data'): Or(Use(is_truthy), VARIABLE_VALIDATOR),
+                    Optional('new_host_delay'): Or(Use(int), VARIABLE_VALIDATOR),
+                    Optional('no_data_timeframe'): Or(Use(int), VARIABLE_VALIDATOR),
+                    Optional('timeout_h'): Or(Use(int), VARIABLE_VALIDATOR),
+                    Optional('require_full_window'): Or(Use(is_truthy), VARIABLE_VALIDATOR),
+                    Optional('renotify_interval'): Or(Use(int), VARIABLE_VALIDATOR),
                     Optional('escalation_message'): str,
-                    Optional('notify_audit'): Use(is_truthy),
-                    Optional('locked'): Use(is_truthy),
-                    Optional('include_tags'): Use(is_truthy),
+                    Optional('notify_audit'): Or(Use(is_truthy), VARIABLE_VALIDATOR),
+                    Optional('locked'): Or(Use(is_truthy), VARIABLE_VALIDATOR),
+                    Optional('include_tags'): Or(Use(is_truthy), VARIABLE_VALIDATOR),
                     Optional('thresholds'): {
-                        Optional('critical'): Or(Use(float), str),
-                        Optional('warning'): Or(Use(float), str),
-                        Optional('ok'): Or(Use(float), str)
+                        Optional('critical'): Or(Use(float), VARIABLE_VALIDATOR),
+                        Optional('warning'): Or(Use(float), VARIABLE_VALIDATOR),
+                        Optional('ok'): Or(Use(float), VARIABLE_VALIDATOR)
                     },
-                    Optional('evaluation_delay'): Use(int),
+                    Optional('evaluation_delay'): Or(Use(int), VARIABLE_VALIDATOR),
                     Optional(str): Use(str)
                 }
             }

--- a/data_kennel/version.py
+++ b/data_kennel/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.6.1"
+__version__ = "1.0.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -246,6 +246,11 @@ class DataKennelConfigTests(TestCase):
             ['mock_query_bar', 'mock_query_foo']
         )
 
+        self.assertEqual(
+            [monitor['tags']['foo'] for monitor in interpolated_monitors],
+            ["bar", "foo"]
+        )
+
     def test_composite_interpolation(self):
         """Verify composite monitor interpolation works correctly"""
         interpolated_config = self.composite_config._interpolate_config(MOCK_COMPOSITE_CONFIG[0])


### PR DESCRIPTION
There was an issue where the validation for the config would not allow
variables for certain options in the `option` section. Created a new
Regex validator that looks for the pattern of a variable and allows
that.

Also updated a unit test to verify that variables in subsections are
interpolated.