### PR TITLE
Set Git Hash on Deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ deploy:
   password: $PYPI_PASSWORD
   on:
     branch: master
+before_deploy:
+  - sed --expression "s|GIT_HASH|$TRAVIS_COMMIT|g" --in-place **/version.py

--- a/bin/dk_monitor
+++ b/bin/dk_monitor
@@ -31,7 +31,7 @@ import os
 from docopt import docopt
 from schema import Schema, Or, And, Use, Regex, Optional
 
-from data_kennel.version import __version__
+from data_kennel.version import __version__, __git_hash__
 from data_kennel.monitor import Monitor
 from data_kennel.config import Config
 from data_kennel.util import configure_logging, run_gracefully, print_table, convert_tags_to_dict
@@ -52,7 +52,7 @@ ARGS_SCHEMA = Schema(
 
 def run():
     """Parses command line and dispatches the commands"""
-    args = docopt(__doc__, version="Data Kennel {0}".format(__version__))
+    args = docopt(__doc__, version="Data Kennel {0} (Commit: {1})".format(__version__, __git_hash__))
 
     ARGS_SCHEMA.validate(args)
 

--- a/data_kennel/version.py
+++ b/data_kennel/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.8"
-__git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"
+__version__ = "1.0.9"
+__git_hash__ = "GIT_HASH"


### PR DESCRIPTION
We should still set the git hash when we deploy the project, so updated
the travis job to do that.