### PR TITLE
Return current monitor when no update is needed for a datadog monitor that already exist

### DIFF
--- a/data_kennel/monitor.py
+++ b/data_kennel/monitor.py
@@ -218,6 +218,10 @@ class Monitor(object):
                     return api.Monitor.update(**merged_monitor)
 
                 return merged_monitor
+            else:
+                 logger.info('No updates needed for %s', real_monitor['name'])
+                 return real_monitor
+
         else:
             logger.info('Creating monitor: %s', configured_monitor['name'])
 

--- a/data_kennel/monitor.py
+++ b/data_kennel/monitor.py
@@ -219,8 +219,8 @@ class Monitor(object):
 
                 return merged_monitor
             else:
-                 logger.info('No updates needed for %s', real_monitor['name'])
-                 return real_monitor
+                logger.info('No updates needed for %s', real_monitor['name'])
+                return real_monitor
 
         else:
             logger.info('Creating monitor: %s', configured_monitor['name'])

--- a/data_kennel/version.py
+++ b/data_kennel/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.92"
+__version__ = "1.0.10"
 __git_hash__ = "GIT_HASH"

--- a/data_kennel/version.py
+++ b/data_kennel/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.9"
+__version__ = "1.0.92"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
There is a corner case where the `_create_or_update_monitor` function does not `return` when
 the monitor exist and no changes are needed .

For some reason it didnt  happened before because the  monitor `type: "query alert"` always get update to  `type: "metric alert"`.....